### PR TITLE
fix: handle legacy webdriver promises

### DIFF
--- a/lib/webdriver_sizzle.js
+++ b/lib/webdriver_sizzle.js
@@ -38,27 +38,29 @@ module.exports = function(driver, selenium) {
     }
   };
   one = function(selector) {
-    var finder;
+    var finder, onError;
+    onError = function(err) {
+      throw new Error("Selector " + selector + " matches nothing");
+    };
     finder = function() {
-      return checkSizzleExists().then(injectSizzleIfMissing).then(function() {
+      return checkSizzleExists().then(injectSizzleIfMissing, onError).then(function() {
         return driver.findElement(selenium.By.js(function(selector) {
           return (window.Sizzle(selector) || [])[0];
         }, selector));
-      })["catch"](function(err) {
-        throw new Error("Selector " + selector + " matches nothing");
-      });
+      })["catch"](onError);
     };
     return driver.findElement(finder);
   };
   one.all = function(selector) {
-    var finder;
+    var finder, onError;
+    onError = function(err) {
+      throw new Error("Selector " + selector + " matches nothing");
+    };
     finder = function() {
-      return checkSizzleExists().then(injectSizzleIfMissing).then(function() {
+      return checkSizzleExists().then(injectSizzleIfMissing, onError).then(function() {
         return driver.findElements(selenium.By.js(function(selector) {
           return window.Sizzle(selector) || [];
         }, selector));
-      })["catch"](function(err) {
-        throw new Error("Selector " + selector + " matches nothing");
       });
     };
     return driver.findElements(finder);

--- a/lib/webdriver_sizzle.js
+++ b/lib/webdriver_sizzle.js
@@ -47,7 +47,7 @@ module.exports = function(driver, selenium) {
         return driver.findElement(selenium.By.js(function(selector) {
           return (window.Sizzle(selector) || [])[0];
         }, selector));
-      })["catch"](onError);
+      });
     };
     return driver.findElement(finder);
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webdriver-sizzle",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Locate a selenium-webdriver element by sizzle CSS selector",
   "author": "Good Eggs <open-source@goodeggs.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webdriver-sizzle",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Locate a selenium-webdriver element by sizzle CSS selector",
   "author": "Good Eggs <open-source@goodeggs.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webdriver-sizzle",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Locate a selenium-webdriver element by sizzle CSS selector",
   "author": "Good Eggs <open-source@goodeggs.com>",
   "license": "MIT",

--- a/src/webdriver_sizzle.coffee
+++ b/src/webdriver_sizzle.coffee
@@ -30,28 +30,29 @@ module.exports = (driver, selenium = require('selenium-webdriver')) ->
         """
 
   one = (selector) ->
+    onError = (err) -> throw new Error "Selector #{selector} matches nothing"
     finder = ->
-      checkSizzleExists().then(injectSizzleIfMissing)
+      # webdriver promises may not be native Promises, so can't use `.catch()`
+      checkSizzleExists().then(injectSizzleIfMissing, onError)
       .then ->
         driver.findElement selenium.By.js \
           (selector)->
             (window.Sizzle(selector)||[])[0]  # one
           , selector
-      .catch (err)->
-        throw new Error "Selector #{selector} matches nothing"
+      .catch(onError)
 
     driver.findElement(finder)
 
   one.all = (selector) ->
+    onError = (err) -> throw new Error "Selector #{selector} matches nothing"
     finder = ->
-      checkSizzleExists().then(injectSizzleIfMissing)
+      # webdriver promises may not be native Promises, so can't use `.catch()`
+      checkSizzleExists().then(injectSizzleIfMissing, onError)
       .then ->
         driver.findElements selenium.By.js \
           (selector)->
             window.Sizzle(selector)||[]  # all
           , selector
-      .catch (err)->
-        throw new Error "Selector #{selector} matches nothing"
 
     driver.findElements(finder)
 

--- a/src/webdriver_sizzle.coffee
+++ b/src/webdriver_sizzle.coffee
@@ -39,7 +39,6 @@ module.exports = (driver, selenium = require('selenium-webdriver')) ->
           (selector)->
             (window.Sizzle(selector)||[])[0]  # one
           , selector
-      .catch(onError)
 
     driver.findElement(finder)
 

--- a/test/webdriver_sizzle.test.coffee
+++ b/test/webdriver_sizzle.test.coffee
@@ -1,6 +1,7 @@
 assert = require 'assert'
 path = require 'path'
 webdriver = require 'selenium-webdriver'
+
 webdriverSizzle = require '..'
 
 {WebElement} = webdriver
@@ -56,9 +57,13 @@ describe 'webdriver-sizzle', ->
       describe 'that matches no elements', ->
         it 'rejects with an error that includes the selector', (done) ->
           $('.does-not-match')
-          .catch (expectedErr) ->
-            assert /does-not-match/.test(expectedErr?.message)
-            done()
+          .then(
+            () ->
+              done(new Error('expected promise to reject'))
+            (expectedErr) ->
+              assert /does-not-match/.test(expectedErr?.message)
+              done()
+          )
 
         # TODO? -- this doesn't work, b/c of the way it's implemented
         # in selenium-webdriver. doesn't seem that critical to work around.


### PR DESCRIPTION
I'm not too sure what changed that revealed this, but it seems in some cases we're getting legacy webdriver promises that aren't compliant with the native Promise spec in that they're missing `catch`.

This isn't a maintained module so I don't feel too bad about making this change without digging deeper.