### PR TITLE
release: v0.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webdriver-sizzle",
-  "version": "0.3.0",
+  "version": "0.3.4",
   "description": "Locate a selenium-webdriver element by sizzle CSS selector",
   "author": "Good Eggs <open-source@goodeggs.com>",
   "license": "MIT",


### PR DESCRIPTION
I prematurely published some bad versions under 0.3.1, 0.3.2, and 0.3.3.

I marked them as deprecated via `npm deprecate`.

This is 0.3.0 republished as 0.3.4 for good measure, to minimize any impacts on consumers.